### PR TITLE
no age shaming

### DIFF
--- a/src/extension/manifest.json
+++ b/src/extension/manifest.json
@@ -2,7 +2,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "gout@regseb.github.io",
-      "strict_min_version": "117.0"
+      "strict_min_version": "1"
     }
   },
   "manifest_version": 2,
@@ -31,7 +31,7 @@
     "persistent": true
   },
   "homepage_url": "https://github.com/regseb/gout",
-  "minimum_chrome_version": "117",
+  "minimum_chrome_version": "1",
   "permissions": [
     "<all_urls>",
     "activeTab",


### PR DESCRIPTION
users of old browsers might not use browser extensions or know what they are doing. if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 116 > Number(navigator.userAgent.match(new RegExp(Chrome|Firefox + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 116+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by its button or storage change.)